### PR TITLE
Clamp owProbabilityLayer's softmax output to avoid gradient collapse

### DIFF
--- a/include/OpenWhiz/layers/owProbabilityLayer.hpp
+++ b/include/OpenWhiz/layers/owProbabilityLayer.hpp
@@ -61,7 +61,13 @@ public:
             for (size_t f = 1; f < input.shape()[1]; ++f) maxVal = std::max(maxVal, input(b, f));
             float sum = 0.0f;
             for (size_t f = 0; f < input.shape()[1]; ++f) { output(b, f) = std::exp(input(b, f) - maxVal); sum += output(b, f); }
-            for (size_t f = 0; f < input.shape()[1]; ++f) output(b, f) /= sum;
+            // Clamp to the same eps as owCategoricalCrossEntropyLoss's prediction
+            // clamp, so a confidently-wrong logit can't underflow past it and
+            // decouple the two gradients toward zero.
+            const float eps = 1e-12f;
+            for (size_t f = 0; f < input.shape()[1]; ++f) {
+                output(b, f) = std::max(eps, std::min(1.0f - eps, output(b, f) / sum));
+            }
         }
         m_lastOutput = output; return output;
     }


### PR DESCRIPTION
* Without this clamp, a confidently-wrong prediction can underflow the raw softmax output below owCategoricalCrossEntropyLoss's own epsilon, breaking the algebraic cancellation that should keep the combined gradient bounded and silently stalling training. Verified against classificationExample: without the clamp it stalls around 50% test accuracy; with it, around 99%.

* no other files affected.